### PR TITLE
Add `title` attribute with `schedule.title` to schedule blocks

### DIFF
--- a/src/js/view/template/week/time.hbs
+++ b/src/js/view/template/week/time.hbs
@@ -8,7 +8,7 @@
                 {{#fi left '!==' 0}}
                     padding-left: {{@root.styles.paddingLeft}};
                 {{/fi}}
-            ">
+            " title="{{model.title}}">
             <div data-schedule-id="{{model.id}}" data-calendar-id="{{model.calendarId}}" class="{{CSS_PREFIX}}time-schedule {{#if model.isFocused}}{{CSS_PREFIX}}time-schedule-focused {{/if}}"
                 style="
                 {{#unless croppedEnd}}


### PR DESCRIPTION
#### What?
- [x] When hovering over a scheduled time block, display the `schedule.title` via the browser's tooltip by adding the `title` atribute to the schedule block wrapping element.

#### Show me:
https://user-images.githubusercontent.com/25407841/217541519-d402092a-b2c6-4433-943b-684cdf645af9.mov

